### PR TITLE
Aggiunto spaghetti script per l'aggiunta automatica degli algoritmi di A3C5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+code.tex
+clean-cpp
+
 ## Core latex/pdflatex auxiliary files:
 *.aux
 *.lof

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Algorithm-Anthology"]
+	path = Algorithm-Anthology
+	url = https://github.com/alxli/Algorithm-Anthology

--- a/README.md
+++ b/README.md
@@ -1,2 +1,156 @@
 # ICPC-notebook
 Notebook per le gare ACM ICPC 
+
+### Istruzioni
+Per inserire gli algoritmi desiderati all'interno del notebook è necesario modificare l'array `$selected` nello script `algo-selector.sh` e aggiungere i propri desiderata aggiungendo il codice corrispondente:
+
+```text
+1.2.2 Maximal Subarray Sum (Kadane's)
+1.2.4 Subset Sum (Meet-in-the-Middle)
+1.3.2 Ternary Search
+1.2.5 Maximal Zero Submatrix
+1.1.1 Sorting Algorithms
+1.3.3 Hill Climbing
+1.3.5 Convex Hull Trick (Fully Dynamic)
+1.4.2 Cycle Detection (Brent's)
+1.3.1 Binary Search
+1.1.5 Selection (Quickselect)
+1.4.1 Cycle Detection (Floyd's)
+1.5.1 Binary Exponentiation
+1.3.4 Convex Hull Trick (Semi-Dynamic)
+1.1.2 Array Rotation
+1.1.3 Counting Inversions
+1.2.3 Majority Element (Boyer-Moore)
+1.2.1 Longest Increasing Subsequence
+1.1.4 Coordinate Compression
+2.2.1 Shortest Path (BFS)
+2.7.2 Maximum Bipartite Matching (Hopcroft-Karp)
+2.3.3 Bridges, Cut-points, and Biconnectivity
+2.6.1 Backtracking - Max Clique (Bron-Kerbosch)
+2.1.4 Unweighted Tree Centers (DFS
+2.8.2 Shortest Hamiltonian Path
+2.2.2 Shortest Path (Dijkstra's)
+2.5.4 Max Flow (Push-Relabel)
+2.3.2 Strongly Connected Components (Tarjan's)
+2.5.3 Max Flow (Dinic's)
+2.1.1 Graph Class and Depth-First Search
+2.7.3 Maximum Graph Matching (Edmonds's)
+2.1.3 Eulerian Cycles (DFS)
+2.8.1 Shortest Hamiltonian Cycle (TSP)
+2.3.1 Strongly Connected Components (Kosaraju's)
+2.7.1 Maximum Bipartite Matching (Kuhn's)
+2.1.2 Topological Sorting (DFS)
+2.5.1 Max Flow (Ford-Fulkerson)
+2.4.1 Minimal Spanning Tree (Prim's)
+2.2.4 Shortest Path (Floyd-Warshall)
+2.2.3 Shortest Path (Bellman-Ford)
+2.4.2 Minimal Spanning Tree (Kruskal's)
+2.5.2 Max Flow (Edmonds-Karp)
+2.6.2 Backtracking - Graph Coloring
+3.4.4 2D Range Tree
+3.3.6 Implicit Treap
+3.2.5 Splay Tree
+3.5.7 2D Fenwick Tree (Compressed)
+3.3.5 Segment Tree (Compressed)
+3.1.2 Randomized Mergeable Heap
+3.2.7 Interval Treap
+3.3.1 Sparse Table (Range Minimum Query)
+3.4.5 K-d Tree (2D Range Query)
+3.4.1 Quadtree (Point Update)
+3.6.5 Heavy Light Decomposition
+3.3.3 Segment Tree (Point Update)
+3.2.4 Red-Black Tree
+3.3.4 Segment Tree (Range Update)
+3.1.3 Skew Heap
+3.2.1 Binary Search Tree
+3.6.2 Disjoint Set Forest (Compressed)
+3.2.8 Hash Map
+3.4.7 R-Tree (Nearest Segment)
+3.4.3 2D Segment Tree
+3.6.1 Disjoint Set Forest (Simple)
+3.1.4 Pairing Heap
+3.4.6 K-d Tree (Nearest Neighbor)
+3.6.3 Lowest Common Ancestor (Sparse Table)
+3.2.3 AVL Tree
+3.2.9 Skip List
+3.5.5 Fenwick Tree (Compressed)
+3.4.2 Quadtree (Range Update)
+3.5.6 2D Fenwick Tree (Simple)
+3.6.6 Link-Cut Tree
+3.6.4 Lowest Common Ancestor (Segment Tree)
+3.2.2 Treap
+3.2.6 Size Balanced Tree
+3.3.2 Square Root Decomposition
+3.5.3 Fenwick Tree (Point Update, Range Query)
+3.1.1 Binary Heap
+3.5.1 Fenwick Tree (Simple)
+3.5.2 Fenwick Tree (Range Update, Point Query)
+3.5.4 Fenwick Tree (Range Update, Range Query)
+4.2.1 Combinatorial Calculations
+4.2.3 Enumerating Permutations
+4.2.5 Enumerating Partitions
+4.6.3 Polynomial Root Finding (Differentiation)
+4.1 Math Utilities
+4.3.3 Primality Testing
+4.2.6 Enumerating Generic Combinatorial Sequences
+4.5.2 Row Reduction
+4.4.2 Big Integers
+4.5.1 Matrix Utilities
+4.3.1 GCD, LCM, Mod Inverse, Chinese Remainder
+4.3.4 Integer Factorization
+4.5.4 LU Decomposition
+4.6.2 Root Finding (Iteration)
+4.6.5 Polynomial Root Finding (RPOLY)
+4.5.3 Determinant and Inverse
+4.4.1 Big Integers (Simple)
+4.6.4 Polynomial Root Finding (Laguerre's)
+4.3.2 Prime Generation
+4.2.4 Enumerating Combinations
+4.5.5 Simplex Algorithm
+4.4.3 Rational Numbers
+4.7.1 Integration (Simpson's)
+4.6.1 Root Finding (Bracketing)
+4.2.2 Enumerating Arrangements
+4.3.5 Euler's Totient Function
+5.3.4 Minimum Enclosing Circle
+5.4.2 Polygon Union and Intersection
+5.1.4 Triangle (2D)
+5.4.4 Delaunay Triangulation (Fast)
+5.1.5 Rectangle (2D)
+5.3.6 Closest Pair
+5.0 Geometry Library (2D)
+5.2.3 Line Intersection (2D)
+5.1.3 Circle (2D)
+5.3.5 Diameter of Points
+5.2.4 Circle Intersection (2D)
+5.4.1 Convex Polygon Cut
+5.3.1 Polygon Sorting and Area
+5.4.3 Delaunay Triangulation (Simple)
+5.3.7 Segment Intersection Finding
+5.3.2 Point-in-Polygon (Ray Casting)
+5.2.2 Distances (2D)
+5.1.2 Line (2D)
+5.2.1 Angles (2D)
+5.1.1 Point (2D)
+5.3.3 Convex Hull (Monotone Chain)
+6.4.2 Longest Common Subsequence
+6.4.3 Edit Distance
+6.3.1 String Searching (KMP)
+6.3.3 String Searching (Z Algorithm)
+6.2.1 Recursive Descent Parsing
+6.6.1 Trie (Simple)
+6.1 Strings Toolbox
+6.6.3 Suffix Tree (Ukkonen's Algorithm)
+6.6.4 Suffix Automaton
+6.3.2 String Searching (Aho-Corasick)
+6.2.3 Shunting Yard Parsing
+6.4.1 Longest Common Substring
+6.5.3 Suffix and LCP Array (Linear DC3)
+6.5.1 Suffix and LCP Array (N log^2 N)
+6.2.2 Recursive Descent Parsing (Simple)
+6.6.2 Radix Tree
+6.5.2 Suffix and LCP Array (N log N)
+```
+
+poi basterà lanciare lo script, compilare `notebook.tex` per ottenere un documento contenete gli algoritmi scelti in ordine alfabetico.
+

--- a/algo-selector.sh
+++ b/algo-selector.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+# Path del codice della repo
 REPO="Algorithm-Anthology/Section-*"
+# Directory per il salvataggio dei file puliti
 SAVE="clean-cpp"
+# Estensione dei file
 CODE_EXT="*.cpp"
+# File di output
 ALGO_TEX="code.tex"
 
+# Stringa di compilazione ottenuta dalle specifiche SWERC
 compilation_str="g++ -g -O2 -Wall -Wextra -std=gnu++14 -static -c -o \"%s\" \"%s\" -lm"
+# Algoritmi selezionati
 selected=(
         "2.3.2" "6.1" "1.3.4"
         "1.4.1" "2.5.2" "2.7.2"
@@ -16,6 +22,7 @@ selected=(
 rm -rf "$SAVE"
 mkdir -p "$SAVE"
 
+# Salva una copia dell'algoritmo in SAVE se il codice corrisponde
 for code in $REPO/$CODE_EXT; do
     for s in ${selected[*]}; do
         if grep -q "/$s " <<< "$code"; then
@@ -27,10 +34,15 @@ done
 tmp=$(mktemp)
 echo > "$ALGO_TEX"
 for saved in $SAVE/$CODE_EXT; do
+    # Elimina il main e la parte per il testing
     sed -i '/\/\*\*\*.*/,$d' "$saved"
+    # Aggiungi namespace std
     sed '0,/\(#include <[a-z]\+>.*$\)\+/s//using namespace std;\n&/' <( tac "$saved") | tac > "$tmp"
     cat "$tmp" > "$saved"
+    # Rimuovi tutti gli std::
     sed -i 's/std:://g' "$saved"
+    # Mi sono arreso a farlo in python perche mi rifiuto di scrivere altro sed
+    # Inline della parte descrittiva dei commenti multilinea
     python - << EOF
 import re
 comment_state = False
@@ -63,14 +75,18 @@ with open("${saved}", 'w') as f:
         f.write("%s" % l)
 EOF
     eval_comp_str="$(printf "$compilation_str" "$tmp" "$saved" )"
+    # Testa la compliazione del file e stampa il risultato
     if eval "$eval_comp_str" &>/dev/null; then
         printf "OK %s\n" "$saved"
     else
         printf "KO %s\n" "$saved"
     fi
+    # Pulizia del nome di salvataggio
     clean_name=$(sed 's/[0-9]\+\(\.[0-9]\+\)\+ //g;s/ /_/g' <(basename "$saved"))
+    # Pulizia del titolo della sezione
     tex_name=$(sed   's/[0-9]\+\(\.[0-9]\+\)\+ //g;s/\.cpp//' <(basename "$saved"))
     mv "$saved" "$SAVE"/"$clean_name"
+    # Generazione del documento tex
     cat << EOF >> "$ALGO_TEX"
 \subsubsection*{${tex_name}}
 \lstinputlisting[style=cpp]{${SAVE}/${clean_name}}

--- a/algo-selector.sh
+++ b/algo-selector.sh
@@ -65,7 +65,7 @@ with open("${saved}", 'r') as f:
 
         if re.match("\/\*", l):
             comment_state = True
-            new_file[-1] = new_file[-1].strip() + ' '
+            new_file[-1] = new_file[-1].strip()
         if re.match("\*\/", l):
             comment_state = False
             complexity_state = False

--- a/algo-selector.sh
+++ b/algo-selector.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+REPO="Algorithm-Anthology/Section-*"
+SAVE="clean-cpp"
+CODE_EXT="*.cpp"
+ALGO_TEX="code.tex"
+
+compilation_str="g++ -g -O2 -Wall -Wextra -std=gnu++14 -static -c -o \"%s\" \"%s\" -lm"
+selected=(
+        "2.3.2" "6.1" "1.3.4"
+        "1.4.1" "2.5.2" "2.7.2"
+        "5.3.4" "5.3.5" "5.3.6"
+        "3.2.5" "3.3.4"
+        )
+
+rm -rf "$SAVE"
+mkdir -p "$SAVE"
+
+for code in $REPO/$CODE_EXT; do
+    for s in ${selected[*]}; do
+        if grep -q "/$s " <<< "$code"; then
+            cp "$code" "$SAVE/$(basename "$code")"
+        fi
+    done
+done
+
+tmp=$(mktemp)
+echo > "$ALGO_TEX"
+for saved in $SAVE/$CODE_EXT; do
+    sed -i '/\/\*\*\*.*/,$d' "$saved"
+    sed '0,/\(#include <[a-z]\+>.*$\)\+/s//using namespace std;\n&/' <( tac "$saved") | tac > "$tmp"
+    cat "$tmp" > "$saved"
+    sed -i 's/std:://g' "$saved"
+    python - << EOF
+import re
+comment_state = False
+complexity_state = False
+lines = []
+new_file = []
+with open("${saved}", 'r') as f:
+    lines = f.readlines()
+    for l in lines:
+        if comment_state:
+            if re.match(".*Complexity\:", l) and not complexity_state:
+                complexity_state = True
+                new_file[-1] = new_file[-1] + '\n\n' + l
+            elif complexity_state:
+                new_file[-1] = new_file[-1] + l
+            else:
+                new_file[-1] = new_file[-1] + l.strip() + ' '
+        else:
+            new_file.append(l)
+
+        if re.match("\/\*", l):
+            comment_state = True
+            new_file[-1] = new_file[-1].strip() + ' '
+        if re.match("\*\/", l):
+            comment_state = False
+            complexity_state = False
+            new_file[-1] = new_file[-1][:-4] + '*/\n'
+with open("${saved}", 'w') as f:
+    for l in new_file:
+        f.write("%s" % l)
+EOF
+    eval_comp_str="$(printf "$compilation_str" "$tmp" "$saved" )"
+    if eval "$eval_comp_str" &>/dev/null; then
+        printf "OK %s\n" "$saved"
+    else
+        printf "KO %s\n" "$saved"
+    fi
+    clean_name=$(sed 's/[0-9]\+\(\.[0-9]\+\)\+ //g;s/ /_/g' <(basename "$saved"))
+    tex_name=$(sed   's/[0-9]\+\(\.[0-9]\+\)\+ //g;s/\.cpp//' <(basename "$saved"))
+    mv "$saved" "$SAVE"/"$clean_name"
+    cat << EOF >> "$ALGO_TEX"
+\subsubsection*{${tex_name}}
+\lstinputlisting[style=cpp]{${SAVE}/${clean_name}}
+EOF
+done
+rm "$tmp"
+

--- a/algo-selector.sh
+++ b/algo-selector.sh
@@ -31,8 +31,10 @@ for code in $REPO/$CODE_EXT; do
     done
 done
 
+# File temporaneo per test di compilazione
 tmp=$(mktemp)
-echo > "$ALGO_TEX"
+# Reset del file tex
+: > "$ALGO_TEX"
 for saved in $SAVE/$CODE_EXT; do
     # Elimina il main e la parte per il testing
     sed -i '/\/\*\*\*.*/,$d' "$saved"

--- a/notebook.tex
+++ b/notebook.tex
@@ -12,9 +12,8 @@
 
 \usepackage[pdftex]{graphicx} % Required for including pictures
 \usepackage{listings}
-\usepackage{xcolor}
+\usepackage[usenames,dvipsnames]{color}
 \usepackage{enumitem} 
-
 
 \usepackage[all]{nowidow} % Tries to remove widows
 
@@ -33,13 +32,28 @@
 \rhead{\thepage}
 \lhead{Università degli Studi di Verona}
 
-\usepackage{blindtext}
+\renewcommand{\ttdefault}{cmtt}
+%\renewcommand{\ttdefault}{pcr}
+\lstdefinestyle{cpp}{
+    language=C++,
+    breaklines=true,
+    showstringspaces=false,
+    %belowcaptionskip=1\baselineskip,
+    xleftmargin=\parindent,
+    basicstyle=\fontsize{5.5}{6}\ttfamily\bfseries,
+    keywordstyle=\bfseries\color{NavyBlue},
+    commentstyle=\itshape\color{RedViolet}\tiny,
+    identifierstyle=\color{Black},
+    stringstyle=\color{LimeGreen},
+    extendedchars=\true,
+    inputencoding=utf8x,
+}
 
 \begin{document}
 \begin{landscape}
-\begin{multicols}{2}
+\begin{multicols}{3}
 
-\blinddocument
+    \input{code.tex}
 
 \end{multicols}
 \end{landscape}

--- a/notebook.tex
+++ b/notebook.tex
@@ -32,15 +32,15 @@
 \rhead{\thepage}
 \lhead{Università degli Studi di Verona}
 
-\renewcommand{\ttdefault}{cmtt}
-%\renewcommand{\ttdefault}{pcr}
+%\renewcommand{\ttdefault}{cmtt}
+\renewcommand{\ttdefault}{pcr}
 \lstdefinestyle{cpp}{
     language=C++,
     breaklines=true,
     showstringspaces=false,
-    %belowcaptionskip=1\baselineskip,
+    belowcaptionskip=1\baselineskip,
     xleftmargin=\parindent,
-    basicstyle=\fontsize{5.5}{6}\ttfamily\bfseries,
+    basicstyle=\fontsize{6}{4.5}\ttfamily\bfseries,
     keywordstyle=\bfseries\color{NavyBlue},
     commentstyle=\itshape\color{RedViolet}\tiny,
     identifierstyle=\color{Black},


### PR DESCRIPTION
Lo script si occupa di ripulire le parti inutili e riformattare commenti, generando un documento tex da inserire nel corpo del template contente gli algoritmi di A3C5 ordinati alfabeticamente.

Se necessario è possibile implementare lo stesso ordinamento specificato in input.